### PR TITLE
fix: #10 predownload-404-resourcesBasePath-null

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,11 @@ src/wutheringwaves-cli-manager-*/
 source.tar.gz
 *.tar.gz
 PKGBUILD
+
+# Test and development
+test-scripts/
+*.exe
+*.dll
+*.zip
+group_*_output/
+Client/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ww-manager"
-version = "2.1.10"
+version = "2.1.11"
 description = "鸣潮命令行管理器"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/ww_manager/core.py
+++ b/src/ww_manager/core.py
@@ -370,7 +370,10 @@ class WGameManager:
 
     def sync_files(self, force_check_md5=False):
         # 确保获取的是当前版本的配置
-        res_base = self.launcher_info["default"]["resourcesBasePath"]
+        default_info = self.launcher_info["default"]
+        res_base = default_info.get("resourcesBasePath") or default_info.get("baseUrl")
+        if not res_base:
+            raise WWError("无法获取资源路径配置 (resourcesBasePath 和 baseUrl 均为空)")
         res_list = self.game_index["resource"]
 
         tasks = []
@@ -459,7 +462,10 @@ class WGameManager:
             raise WWError("当前服务器未开放预下载，或未能获取到预下载配置。")
 
         pre_info = self.launcher_info.get("predownload", {})
-        res_base = pre_info.get("config", {}).get("resourcesBasePath", "")
+        pre_config = pre_info.get("config", {})
+        res_base = pre_config.get("resourcesBasePath") or pre_config.get("baseUrl")
+        if not res_base:
+            raise WWError("无法获取预下载资源路径配置 (resourcesBasePath 和 baseUrl 均为空)")
         res_list = index.get("resource", [])
 
         if not res_list:


### PR DESCRIPTION
- 修复 `download_predownload`: `resourcesBasePath` 为 None 时回退到""导致404
- `sync_files`: 同上
- 两处均加空值校验，抛出 Error 避免静默 404