### PR TITLE
fix: 修复_download_file文件复用临时文件导致的Range过大异常

### DIFF
--- a/src/ww_manager/core.py
+++ b/src/ww_manager/core.py
@@ -261,7 +261,7 @@ class WGameManager:
         for attempt in range(retries):
             try:
                 resume_byte = 0
-                if temp_file.exists() and temp_file.stat().st_size < expected_size:
+                if temp_file.exists() and temp_file.stat().st_size <= expected_size:
                     resume_byte = temp_file.stat().st_size
 
                 # 如果已完成，更新进度条并跳过

--- a/src/ww_manager/core.py
+++ b/src/ww_manager/core.py
@@ -261,7 +261,7 @@ class WGameManager:
         for attempt in range(retries):
             try:
                 resume_byte = 0
-                if temp_file.exists():
+                if temp_file.exists() and temp_file.stat().st_size < expected_size:
                     resume_byte = temp_file.stat().st_size
 
                 # 如果已完成，更新进度条并跳过


### PR DESCRIPTION
临时文件过大时没有正确清除，导致后续请求反复触发Range不适用的报错